### PR TITLE
Add editing and deletion functionality to instruments datatable

### DIFF
--- a/src/lib/remote/admin/scores.remote.ts
+++ b/src/lib/remote/admin/scores.remote.ts
@@ -2,7 +2,11 @@ import { form, getRequestEvent, query } from '$app/server';
 import { requireRole } from '$lib/server/utils/auth';
 import { Constants } from '$lib/types/database.types';
 import { getSupabaseServerAdmin } from '$lib/server/utils/supabase';
-import { createInstrumentSchema } from '$lib/schemas/remote/admin/scores';
+import {
+	createInstrumentSchema,
+	deleteInstrumentSchema,
+	updateInstrumentSchema
+} from '$lib/schemas/remote/admin/scores';
 
 export const getInstruments = query(async () => {
 	const {
@@ -41,3 +45,50 @@ export const createInstrument = form(createInstrumentSchema, async (data) => {
 
 	return { success: true };
 });
+
+export const updateInstrument = form(updateInstrumentSchema, async ({ id, name }, invalid) => {
+	const {
+		locals: { getSession }
+	} = getRequestEvent();
+
+	const session = await getSession();
+
+	await requireRole(session?.user, Constants.public.Enums.Role[0]);
+
+	const supabaseAdmin = getSupabaseServerAdmin();
+
+	const { error } = await supabaseAdmin.from('instruments').update({ name }).eq('id', id);
+
+	if (error) {
+		invalid('Het is niet gelukt om het instrument aan te passen. Probeer het later opnieuw.');
+		return;
+	}
+
+	await getInstruments().refresh();
+
+	return { success: true };
+});
+
+export const deleteInstrument = form(deleteInstrumentSchema, async ({ id }, invalid) => {
+	const {
+		locals: { getSession }
+	} = getRequestEvent();
+
+	const session = await getSession();
+
+	await requireRole(session?.user, Constants.public.Enums.Role[0]);
+
+	const supabaseAdmin = getSupabaseServerAdmin();
+
+	const { error } = await supabaseAdmin.from('instruments').delete().eq('id', id);
+
+	if (error) {
+		invalid('Het is niet gelukt om het instrument te verwijderen. Probeer het later opnieuw.');
+		return;
+	}
+
+	await getInstruments().refresh();
+
+	return { success: true };
+});
+

--- a/src/lib/schemas/remote/admin/scores.ts
+++ b/src/lib/schemas/remote/admin/scores.ts
@@ -3,3 +3,12 @@ import * as z from 'zod';
 export const createInstrumentSchema = z.object({
 	name: z.string().min(1, 'Vul een naam in')
 });
+
+export const updateInstrumentSchema = z.object({
+	id: z.uuid(),
+	name: z.string().min(1, 'Vul een naam in')
+});
+
+export const deleteInstrumentSchema = z.object({
+	id: z.uuid()
+});

--- a/src/routes/admin/settings/instruments/data-table.svelte
+++ b/src/routes/admin/settings/instruments/data-table.svelte
@@ -1,18 +1,44 @@
 <script lang="ts">
 	import { type ColumnDef, getCoreRowModel } from '@tanstack/table-core';
-	import { createSvelteTable, FlexRender } from '$lib/components/ui/data-table';
+	import { createSvelteTable, FlexRender, renderSnippet } from '$lib/components/ui/data-table';
 	import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '$lib/components/ui/table';
 	import CreateInstrumentButton from './create-instrument-button.svelte';
 	import type { Tables } from '$lib/types/database.types';
+	import { Button } from '$lib/components/ui/button';
+	import {
+		DropdownMenu,
+		DropdownMenuTrigger,
+		DropdownMenuContent,
+		DropdownMenuItem,
+		DropdownMenuSeparator
+	} from '$lib/components/ui/dropdown-menu';
+	import EllipsisIcon from '@lucide/svelte/icons/ellipsis';
+	import EditInstrumentDialog from './edit-instrument-dialog.svelte';
+	import DeleteInstrumentDialog from './delete-instrument-dialog.svelte';
 
 	const columns: ColumnDef<Tables<'instruments'>>[] = [
 		{
 			accessorKey: 'name',
 			header: 'Instrument'
+		},
+		{
+			id: 'actions',
+			cell: ({ row }) => {
+				return renderSnippet(Actions, { row: row.original });
+			}
 		}
 	];
 
 	let { data }: { data: Tables<'instruments'>[] } = $props();
+
+	let editInstrumentDialog = $state({
+		open: false,
+		instrument: null as Tables<'instruments'> | null
+	});
+	let deleteInstrumentDialog = $state({
+		open: false,
+		instrument: null as Tables<'instruments'> | null
+	});
 
 	let table = $derived(createSvelteTable({
 		data,
@@ -21,16 +47,15 @@
 	}));
 </script>
 
-<div class="flex flex-col gap-2">
+<div class="flex flex-col gap-2 max-w-sm">
 	<div class="flex justify-end">
 		<CreateInstrumentButton />
 	</div>
-	<div class="rounded-md border">
+	<div class="rounded-md border [&_th]:px-4 [&_td]:px-4 [&_th:last-child]:w-0 [&_td:last-child]:w-0">
 		<Table>
 			<TableHeader class="bg-muted sticky top-0 z-10">
 				{#each table.getHeaderGroups() as headerGroup (headerGroup.id)}
 					<TableRow>
-						<TableHead class="w-8"></TableHead>
 						{#each headerGroup.headers as header (header.id)}
 							<TableHead colspan={header.colSpan}>
 								{#if !header.isPlaceholder}
@@ -47,7 +72,6 @@
 			<TableBody>
 				{#each table.getRowModel().rows as row (row.id)}
 					<TableRow data-state={row.getIsSelected() && "selected"}>
-						<TableCell />
 						{#each row.getVisibleCells() as cell (cell.id)}
 							<TableCell>
 								<FlexRender
@@ -62,3 +86,28 @@
 		</Table>
 	</div>
 </div>
+
+<EditInstrumentDialog bind:open={editInstrumentDialog.open} instrument={editInstrumentDialog.instrument} />
+<DeleteInstrumentDialog bind:open={deleteInstrumentDialog.open} instrument={deleteInstrumentDialog.instrument} />
+
+{#snippet Actions({ row }: {row: Tables<'instruments'>})}
+	<DropdownMenu>
+		<DropdownMenuTrigger>
+			{#snippet child({ props })}
+				<Button {...props} variant="ghost" size="icon" class="relative size-8 p-0">
+					<span class="sr-only">Open menu</span>
+					<EllipsisIcon />
+				</Button>
+			{/snippet}
+		</DropdownMenuTrigger>
+		<DropdownMenuContent>
+			<DropdownMenuItem onclick={() => editInstrumentDialog = {open: true, instrument: row}}>
+				Bewerken
+			</DropdownMenuItem>
+			<DropdownMenuSeparator />
+			<DropdownMenuItem variant="destructive" onclick={() => deleteInstrumentDialog = {open: true, instrument: row}}>
+				Verwijderen
+			</DropdownMenuItem>
+		</DropdownMenuContent>
+	</DropdownMenu>
+{/snippet}

--- a/src/routes/admin/settings/instruments/delete-instrument-dialog.svelte
+++ b/src/routes/admin/settings/instruments/delete-instrument-dialog.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import {
+		Dialog,
+		DialogContent,
+		DialogDescription,
+		DialogFooter,
+		DialogHeader,
+		DialogTitle
+	} from '$lib/components/ui/dialog';
+	import type { Tables } from '$lib/types/database.types';
+	import { deleteInstrument } from '$lib/remote/admin/scores.remote';
+	import { deleteInstrumentSchema } from '$lib/schemas/remote/admin/scores';
+	import { DialogClose } from '$lib/components/ui/dialog';
+	import { Button } from '$lib/components/ui/button';
+	import { Issues } from '$lib/components/issues';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert';
+	import CircleCheckIcon from '@lucide/svelte/icons/circle-check';
+	import { Spinner } from '$lib/components/ui/spinner';
+
+	let { open = $bindable(false), instrument }: { open: boolean, instrument: Tables<'instruments'> | null } = $props();
+</script>
+
+<Dialog bind:open>
+	<DialogContent>
+		<form {...deleteInstrument.preflight(deleteInstrumentSchema)}>
+			<input {...deleteInstrument.fields.id.as('hidden', instrument?.id ?? '')} />
+			<DialogHeader>
+				<DialogTitle>
+					Instrument verwijderen
+				</DialogTitle>
+				<DialogDescription>
+					Weet je zeker dat je het instrument
+					<span class="text-foreground">
+						'{instrument?.name}'
+						</span>
+					wilt verwijderen?
+				</DialogDescription>
+			</DialogHeader>
+			<div class="flex flex-col gap-4 py-2">
+				<Issues class="col-span-2" issues={deleteInstrument.fields.allIssues()} />
+
+				{#if (deleteInstrument.result?.success)}
+					<Alert class="col-span-2">
+						<CircleCheckIcon />
+						<AlertDescription>Het instrument is verwijderd</AlertDescription>
+					</Alert>
+				{/if}
+			</div>
+			<DialogFooter>
+				<div class="flex flex-row justify-between w-full gap-4 mt-4">
+					<Button type="submit" variant="destructive">
+						{#if deleteInstrument.pending}
+							<Spinner />
+						{:else}
+							Verwijderen
+						{/if}
+					</Button>
+					<DialogClose>
+						{#snippet child({ props })}
+							<Button type="button" variant="outline" {...props}>Annuleren</Button>
+						{/snippet}
+					</DialogClose>
+				</div>
+			</DialogFooter>
+		</form>
+	</DialogContent>
+</Dialog>
+

--- a/src/routes/admin/settings/instruments/edit-instrument-dialog.svelte
+++ b/src/routes/admin/settings/instruments/edit-instrument-dialog.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import { updateInstrument } from '$lib/remote/admin/scores.remote';
+	import { Input } from '$lib/components/ui/input';
+	import {
+		Dialog,
+		DialogContent,
+		DialogDescription,
+		DialogFooter,
+		DialogHeader,
+		DialogTitle
+	} from '$lib/components/ui/dialog';
+	import CircleCheckIcon from '@lucide/svelte/icons/circle-check';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert';
+	import { Label } from '$lib/components/ui/label';
+	import { Spinner } from '$lib/components/ui/spinner';
+	import { Issues } from '$lib/components/issues';
+	import { updateInstrumentSchema } from '$lib/schemas/remote/admin/scores';
+	import type { Tables } from '$lib/types/database.types';
+
+	let { open = $bindable(false), instrument }: { open: boolean, instrument: Tables<'instruments'> | null } = $props();
+
+	const id = $props.id();
+</script>
+
+
+<Dialog bind:open>
+	<DialogContent>
+		<form {...updateInstrument.preflight(updateInstrumentSchema)}>
+			<input {...updateInstrument.fields.id.as('hidden', instrument?.id ?? '')} />
+			<DialogHeader>
+				<DialogTitle>
+					Instrument bewerken
+				</DialogTitle>
+				<DialogDescription>
+					Bewerk de naam van het instrument
+					<span class="text-foreground">
+						'{instrument?.name}'
+						</span>
+				</DialogDescription>
+			</DialogHeader>
+			<div class="grid grid-cols-[auto_1fr] gap-4 py-4">
+				<Label class="text-right" for="name-{id}">Naam</Label>
+				<Input {...updateInstrument.fields.name.as('text')} class="grow" id="name-{id}" required
+							 value={instrument?.name ?? ''} />
+
+				<Issues class="col-span-2" issues={updateInstrument.fields.allIssues()} />
+
+				{#if (updateInstrument.result?.success)}
+					<Alert class="col-span-2">
+						<CircleCheckIcon />
+						<AlertDescription>De naam van het instrument is aangepast</AlertDescription>
+					</Alert>
+				{/if}
+			</div>
+			<DialogFooter>
+				<Button type="submit">
+					{#if updateInstrument.pending}
+						<Spinner />
+					{:else}
+						Opslaan
+					{/if}
+				</Button>
+			</DialogFooter>
+		</form>
+	</DialogContent>
+</Dialog>
+

--- a/src/routes/admin/settings/users/data-table.svelte
+++ b/src/routes/admin/settings/users/data-table.svelte
@@ -62,7 +62,7 @@
 	<div class="flex justify-end">
 		<InviteButton />
 	</div>
-	<div class="rounded-md border [&_th]:px-4 [&_td]:px-4">
+	<div class="rounded-md border [&_th]:px-4 [&_td]:px-4 [&_th:last-child]:w-0 [&_td:last-child]:w-0">
 		<Table>
 			<TableHeader class="bg-muted sticky top-0 z-10">
 				{#each table.getHeaderGroups() as headerGroup (headerGroup.id)}


### PR DESCRIPTION
This pull request adds full CRUD (Create, Read, Update, Delete) support for managing instruments in the admin settings. It introduces backend endpoints and frontend dialogs for editing and deleting instruments, as well as UI improvements to the instruments data table for easier management.

### Backend: Instrument Management Endpoints

* Added `updateInstrument` and `deleteInstrument` endpoints to `scores.remote.ts`, including authorization checks and schema validation for updating and deleting instruments.
* Defined new Zod schemas: `updateInstrumentSchema` and `deleteInstrumentSchema` to validate instrument update and delete requests.

### Frontend: Data Table and Dialogs

* Enhanced the instruments data table with an "actions" column featuring a dropdown menu for editing and deleting instruments. [[1]](diffhunk://#diff-ae924acb7298ffc009ca4c0006dbb1c0e88e9c5997c91ca07a0c94f996040cbeL3-L33) [[2]](diffhunk://#diff-ae924acb7298ffc009ca4c0006dbb1c0e88e9c5997c91ca07a0c94f996040cbeL50) [[3]](diffhunk://#diff-ae924acb7298ffc009ca4c0006dbb1c0e88e9c5997c91ca07a0c94f996040cbeR89-R113)
* Added `EditInstrumentDialog` and `DeleteInstrumentDialog` components for handling instrument edits and deletions, including form validation, success messages, and error handling. [[1]](diffhunk://#diff-09c396b1a20ac38d9f0473281a74fbca4302c8fda04bc884c641834e99ac93e4R1-R68) [[2]](diffhunk://#diff-238c42951769d12fefa2cbfcd1697c2855df0d13a0047f364b9eb98544871cceR1-R68)

### UI Consistency

* Matched the data table column width styling in the users data table to the instruments data table for consistent layout.