### PR TITLE
Add fallback message to empty data tables in instruments and users se…

### DIFF
--- a/src/routes/admin/settings/instruments/data-table.svelte
+++ b/src/routes/admin/settings/instruments/data-table.svelte
@@ -81,6 +81,12 @@
 							</TableCell>
 						{/each}
 					</TableRow>
+				{:else}
+					<TableRow>
+						<TableCell colspan={columns.length} class="h-24 text-center">
+							Geen resultaten.
+						</TableCell>
+					</TableRow>
 				{/each}
 			</TableBody>
 		</Table>

--- a/src/routes/admin/settings/users/data-table.svelte
+++ b/src/routes/admin/settings/users/data-table.svelte
@@ -92,6 +92,12 @@
 							</TableCell>
 						{/each}
 					</TableRow>
+				{:else}
+					<TableRow>
+						<TableCell colspan={columns.length} class="h-24 text-center">
+							Geen resultaten.
+						</TableCell>
+					</TableRow>
 				{/each}
 			</TableBody>
 		</Table>


### PR DESCRIPTION
This pull request improves the user experience in the data tables for both the instruments and users admin settings pages by providing a clear message when there are no results to display.

- Closing #109 

User feedback improvements:

* Added a "Geen resultaten." (No results) message in the `instruments/data-table.svelte` table when there are no entries to show.
* Added a "Geen resultaten." (No results) message in the `users/data-table.svelte` table when there are no entries to show.…ttings